### PR TITLE
Refactor: Resolve Circular Dependencies via Shared Dependencies Module

### DIFF
--- a/src/ansari/dependencies.py
+++ b/src/ansari/dependencies.py
@@ -1,0 +1,37 @@
+"""
+Global dependencies for the Ansari application.
+
+This file initializes shared resources like the database connection and the API presenter.
+Moving these initializations here avoids circular dependency issues that occur when
+routers (like whatsapp_router) try to import these objects from main_api.py while
+main_api.py is trying to import the routers.
+
+Best Practice:
+Separating instantiation of global objects (Singletons) from the main application entry point
+allows them to be imported by any part of the application without triggering the
+execution of the main application logic or creating import cycles.
+"""
+
+from ansari.agents import Ansari, AnsariClaude
+from ansari.ansari_db import AnsariDB
+from ansari.config import get_settings
+from ansari.presenters.api_presenter import ApiPresenter
+
+# Initialize Database
+# This is a singleton instance used throughout the application
+db = AnsariDB(get_settings())
+
+# Initialize Agent
+# We determine which agent to use based on settings
+agent_type = get_settings().AGENT
+
+if agent_type == "Ansari":
+    ansari = Ansari(get_settings())
+elif agent_type == "AnsariClaude":
+    ansari = AnsariClaude(get_settings())
+else:
+    raise ValueError(f"Unknown agent type: {agent_type}. Must be one of: Ansari, AnsariClaude")
+
+# Initialize Presenter
+# The presenter handles the interaction between the API and the Agent
+presenter = ApiPresenter(ansari)

--- a/src/ansari/presenters/api_presenter.py
+++ b/src/ansari/presenters/api_presenter.py
@@ -8,8 +8,7 @@ from ansari.ansari_db import MessageLogger
 
 
 class ApiPresenter:
-    def __init__(self, app, agent: Ansari | AnsariClaude):
-        self.app = app
+    def __init__(self, agent: Ansari | AnsariClaude):
         self.settings = agent.settings
 
     def complete(self, messages: dict, message_logger: MessageLogger = None):

--- a/src/ansari/routers/whatsapp_router.py
+++ b/src/ansari/routers/whatsapp_router.py
@@ -15,7 +15,7 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 # Get database connection
-from ansari.app.main_api import db, presenter
+from ansari.dependencies import db, presenter
 
 
 # Dependency for verifying WhatsApp service API key


### PR DESCRIPTION
### Context & Issue
I encountered a circular dependency and initialization issue when running the application locally using `python src/ansari/app/main_api.py`.

The architecture involved:
1. `main_api.py` (Parent) importing `whatsapp_router` (Child).
2. `whatsapp_router` importing `db` and `presenter` back from `main_api.py`.

When running `main_api.py` as a script, it executes as `__main__`. However, `whatsapp_router` imports it as `ansari.app.main_api`. This caused Python to load the module twice, resulting in **two separate copies of the database connection and presenter instances**. This is a classic "Parent-Child" circular dependency problem.

### Solution
Instead of using a "band-aid" fix (like moving imports to the bottom of the file or using deferred imports), I decided to refactor the architecture to use a **Shared Dependencies** pattern. This is cleaner and prevents readability problems for newcomers who might be confused by the weird parent-child import relationships.

### Changes
1. **Created `src/ansari/dependencies.py`**:
   - This new file now hosts the initialization of the `db`, `ansari` agent, and `presenter` singletons.
   
2. **Refactored `ApiPresenter`**:
   - Removed the `app` (FastAPI instance) dependency from `ApiPresenter` as it was unused and contributed to coupling.

3. **Updated `main_api.py` & `whatsapp_router.py`**:
   - Both files now import the shared instances from `dependencies.py` instead of `main_api.py` defining them and `whatsapp_router` importing them back.

This change ensures that `db` and `presenter` are true singletons regardless of how the application is started (`uvicorn` vs `python main_api.py`).