### PR TITLE
Fix: Consolidate tool_results and nest documents per Anthropic API spec

### DIFF
--- a/src/ansari/agents/ansari_claude.py
+++ b/src/ansari/agents/ansari_claude.py
@@ -1049,25 +1049,11 @@ class AnsariClaude(Ansari):
             if tool_id not in tool_result_info:
                 logger.warning(f"Adding missing tool_result for tool_use ID {tool_id}")
 
-                # Get tool name for better error messages
-                tool_name = tool_block.get("name", "unknown_tool")
-
-                # Create a fallback tool_result message
+                # Create a fallback tool_result message with no content
                 fallback_result = {
                     "role": "user",
                     "content": [
-                        {"type": "tool_result", "tool_use_id": tool_id, "content": "Please see the references below."},
-                        {
-                            "type": "document",
-                            "source": {
-                                "type": "text",
-                                "media_type": "text/plain",
-                                "data": f"No content found for this tool call. Tool: {tool_name}",
-                            },
-                            "title": "No Results",
-                            "context": f"Tool: {tool_name}",
-                            "citations": {"enabled": False},
-                        },
+                        {"type": "tool_result", "tool_use_id": tool_id},
                     ],
                 }
 
@@ -1123,53 +1109,16 @@ class AnsariClaude(Ansari):
                 logger.warning(f"Removing invalid tool_result block from message {msg_idx}")
                 self.message_history[msg_idx]["content"].pop(block_idx)
 
-        # 5. Ensure each tool_result has at least one document block
-        for tool_id, result_idx in tool_result_info.items():
-            # Skip if the message was removed
-            if result_idx in removed_messages:
-                continue
-
-            # Get the tool name for better error messages
-            tool_name = "unknown_tool"
-            if tool_id in tool_use_info:
-                _, tool_block = tool_use_info[tool_id]
-                tool_name = tool_block.get("name", "unknown_tool")
-
-            # Check if this result message has document blocks
-            msg = self.message_history[result_idx]
-            has_document = False
-
-            if isinstance(msg.get("content"), list):
-                for block in msg["content"]:
-                    if isinstance(block, dict) and block.get("type") == "document":
-                        has_document = True
-                        break
-
-            # If no document block found, add a fallback one
-            if not has_document:
-                logger.warning(f"Adding missing document block to tool_result for ID {tool_id}")
-                fallback_doc = {
-                    "type": "document",
-                    "source": {
-                        "type": "text",
-                        "media_type": "text/plain",
-                        "data": f"No content found for this query with tool: {tool_name}",
-                    },
-                    "title": "No Results",
-                    "context": f"Tool: {tool_name}",
-                    "citations": {"enabled": False},
-                }
-                self.message_history[result_idx]["content"].append(fallback_doc)
-
-        # 6. Final check - ensure tool_results are placed immediately after their tool_use blocks
+        # 5. Final check - ensure tool_results are placed immediately after their tool_use blocks
         for tool_id, (use_idx, _) in tool_use_info.items():
             if tool_id in tool_result_info:
                 result_idx = tool_result_info[tool_id]
 
                 # If the result doesn't immediately follow the use, move it
                 if result_idx != use_idx + 1:
-                    logger.warning(f"""Tool_result for ID {tool_id} is at wrong position (found at {result_idx},
-                                   should be {use_idx + 1})""")
+                    logger.warning(
+                        f"Tool_result for ID {tool_id} is at wrong position (found at {result_idx}, should be {use_idx + 1})"
+                    )
 
                     # Skip if the message was already removed
                     if result_idx in removed_messages:
@@ -1197,11 +1146,18 @@ class AnsariClaude(Ansari):
         This is a helper method extracted to avoid code duplication between
         different handlers (tool_use, message_stop, etc.)
 
+        IMPORTANT: All tool results are consolidated into a SINGLE user message.
+        The Anthropic API requires that all tool_results for tool_uses in one
+        assistant message must appear in the same user message immediately after.
+
         Args:
             tool_calls: List of tool calls to process
         """
         if not tool_calls:
             return
+
+        # Collect all tool results into a single content array
+        all_tool_result_content = []
 
         for tc in tool_calls:
             try:
@@ -1224,40 +1180,27 @@ class AnsariClaude(Ansari):
                             # Update the document with the processed version
                             doc.update(processed_doc)
 
-                # CRITICAL: Ensure we always have at least one document block
-                # This prevents Claude API errors where tool_use blocks have no corresponding tool_result with document
+                # If no document blocks, return empty tool_result (no content field needed)
                 if not document_blocks:
-                    # Create a default fallback document block
-                    logger.warning(f"No document blocks found for tool {tc['name']} - adding fallback document block")
-                    fallback_message = f"No content found for the given query with tool: {tc['name']}"
-                    document_blocks = [
+                    logger.warning(f"No document blocks found for tool {tc['name']} - returning empty tool_result")
+                    all_tool_result_content.append(
                         {
-                            "type": "document",
-                            "source": {"type": "text", "media_type": "text/plain", "data": fallback_message},
-                            "title": "No Results",
-                            "context": f"Tool: {tc['name']}",
-                            "citations": {"enabled": False},
+                            "type": "tool_result",
+                            "tool_use_id": tc["id"],
                         }
-                    ]
+                    )
+                else:
+                    # Add tool_result with document blocks INSIDE content (per Anthropic API spec)
+                    tool_result_content = [{"type": "text", "text": "Please see the references below."}]
+                    tool_result_content.extend(document_blocks)
 
-                # Add tool result message with at least one document block
-                logger.debug("Adding a 'tool_result' message to history")
-                self.message_history.append(
-                    {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "tool_result",
-                                "tool_use_id": tc["id"],
-                                "content": "Please see the references below.",
-                            }
-                        ]
-                        + document_blocks,
-                    }
-                )
-
-                # Log the tool result message
-                self._log_message(self.message_history[-1])
+                    all_tool_result_content.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tc["id"],
+                            "content": tool_result_content,
+                        }
+                    )
 
             except Exception as e:
                 logger.error(f"Error processing tool call: {str(e)}")
@@ -1270,29 +1213,24 @@ class AnsariClaude(Ansari):
                     )
                     sentry_sdk.capture_exception(e)
 
-                # Add error as tool result, always including a document block
-                fallback_error_doc = {
-                    "type": "document",
-                    "source": {"type": "text", "media_type": "text/plain", "data": f"Error processing tool: {str(e)}"},
-                    "title": "Error",
-                    "context": f"Tool: {tc['name']}",
-                    "citations": {"enabled": False},
-                }
+                # Add error as tool result with is_error flag
+                all_tool_result_content.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tc["id"],
+                        "is_error": True,
+                    }
+                )
 
-                error_message = {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "tool_result",
-                            "tool_use_id": tc["id"],
-                            "content": str(e),
-                        }
-                    ]
-                    + [fallback_error_doc],  # Always include a document block
-                }
-                self.message_history.append(error_message)
-                # Log the error message
-                self._log_message(self.message_history[-1])
+        # Add ONE consolidated user message with all tool results
+        if all_tool_result_content:
+            logger.debug(f"Adding consolidated tool_result message with {len(tool_calls)} tool results")
+            consolidated_message = {
+                "role": "user",
+                "content": all_tool_result_content,
+            }
+            self.message_history.append(consolidated_message)
+            self._log_message(consolidated_message)
 
     def _finish_response(self, assistant_text, tool_calls):
         """Handle the completion of a response, adding citations and finalizing the assistant message.


### PR DESCRIPTION
## Summary
- Fix Anthropic API 400 error when Claude makes parallel tool calls
- Consolidate all tool_results into ONE user message instead of separate messages
- Nest document blocks inside `tool_result.content` per Anthropic API spec
- Use empty tool_result for no results case
- Use `is_error: true` flag for error cases instead of error documents