### PR TITLE
Fix: Remove bare strings from tool_result.content

### DIFF
--- a/src/ansari/tools/base_search.py
+++ b/src/ansari/tools/base_search.py
@@ -57,7 +57,7 @@ class BaseSearchTool(ABC):
                 {"lang": "en", "text": "English translation"} # Optional
             ]
 
-            Or a list containing a single string "No results found." if no results.
+            Or an empty list if no results were found.
         """
         pass
 

--- a/src/ansari/tools/search_mawsuah.py
+++ b/src/ansari/tools/search_mawsuah.py
@@ -51,7 +51,7 @@ class SearchMawsuah(SearchVectara):
         documents = super().format_as_ref_list(response)
 
         if not documents:
-            return ["No results found."]
+            return []
 
         # Update documents with just Arabic text and citation support
         for doc in documents:

--- a/src/ansari/tools/search_tafsir_encyc.py
+++ b/src/ansari/tools/search_tafsir_encyc.py
@@ -73,7 +73,7 @@ class SearchTafsirEncyc(SearchUsul):
         """
         # Check for empty results in different ways:
         if not results or "results" not in results or not results.get("results", []):
-            return ["No results found."]
+            return []
 
         formatted_results = []
         for result in results.get("results", []):
@@ -131,7 +131,7 @@ class SearchTafsirEncyc(SearchUsul):
 
             formatted_results.append(formatted_text)
 
-        return formatted_results if formatted_results else ["No results found."]
+        return formatted_results if formatted_results else []
 
     def format_as_ref_list(self, results: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Format raw results as a list of reference documents for Claude.
@@ -144,7 +144,7 @@ class SearchTafsirEncyc(SearchUsul):
         """
         # Check for empty results in different ways:
         if not results or "results" not in results or not results.get("results", []):
-            return ["No results found."]
+            return []
 
         documents = []
         for result in results.get("results", []):
@@ -218,7 +218,7 @@ class SearchTafsirEncyc(SearchUsul):
                 }
             )
 
-        return documents if documents else ["No results found."]
+        return documents if documents else []
 
     def _ref_object_to_string(self, ref_obj: Dict[str, Any]) -> str:
         """Convert a reference object to a string representation.
@@ -277,11 +277,11 @@ class SearchTafsirEncyc(SearchUsul):
         Returns:
             Dict containing formatted results for Claude
         """
-        formatted_refs = self.format_as_ref_list(results)
+        # Check for empty results
+        if not results or "results" not in results or not results.get("results", []):
+            return {"type": "text", "text": "No results found."}
 
-        # Check if we have actual results or just a "no results" message
-        if len(formatted_refs) == 1 and isinstance(formatted_refs[0], str):
-            return {"type": "text", "text": formatted_refs[0]}
+        formatted_refs = self.format_as_ref_list(results)
 
         # Otherwise, convert each reference to a tool result item
         formatted_items = []

--- a/src/ansari/tools/search_usul.py
+++ b/src/ansari/tools/search_usul.py
@@ -140,7 +140,7 @@ class SearchUsul(BaseSearchTool):
         """
         # Check for empty results in different ways
         if not results or "results" not in results or not results.get("results", []):
-            return ["No results found."]
+            return []
 
         documents = []
         for result in results.get("results", []):

--- a/tests/unit/test_search_tafsir_encyc.py
+++ b/tests/unit/test_search_tafsir_encyc.py
@@ -173,8 +173,7 @@ class TestSearchTafsirEncyc:
 
         # Check the formatted versions for empty results
         formatted_list = self.search_tool.format_as_ref_list(empty_results)
-        assert len(formatted_list) == 1
-        assert formatted_list[0] == "No results found."
+        assert len(formatted_list) == 0
 
         formatted_tool_result = self.search_tool.format_as_tool_result(empty_results)
         assert formatted_tool_result["type"] == "text"


### PR DESCRIPTION
## Summary
- Search tools (`search_mawsuah`, `search_tafsir_encyc`, `search_usul`) returned `["No results found."]` from `format_as_ref_list` when empty, causing bare strings in `tool_result.content` which the Anthropic API rejects
- Return `[]` instead, and sanitize existing DB records on load in `process_message_history`
- Fix `_validate_message_history` to check both sibling (old format) and nested (current format) document locations, and skip error/no-content tool_results
- Fix `search_tafsir_encyc.format_as_tool_result` to check raw results directly instead of relying on `format_as_ref_list` return value

## Details
Tools that return no results don't conform to the specs that Anthropic expects by returning a raw string instead of the expect content object (or none), which causes the request to fail.

Here is a sample of the issue:

<img width="908" height="709" alt="image" src="https://github.com/user-attachments/assets/3261ea0b-bda6-4887-bbf6-2e0d9a677468" />

Which produced this UX in the frontend:

<img width="337" height="703" alt="image" src="https://github.com/user-attachments/assets/5f645fd1-8cf7-448d-a566-08e5d0660f10" />


The issue should now be resolved with the tools returning proper responses along with handling historical messages. 

While debuging, the Usul API returned a 500 internal server error, probably transient, but it would be good to check with the team if we are sending in invalid or deprecated payloads.

```
127.0.0.1:54179 - "POST /api/v2/threads/69852d3cde88a562fd6f187b HTTP/1.1" 200
2026-02-06 10:52:38 | WARNING | ansari.agents.ansari_claude:process_tool_call:507 | No results returned for search_tafsir_encyc with query 'سورة الواقعة الآيات 15-30 تفسير'. Possible rate limiting.
Query failed with code 500, reason Internal Server Error, text {"status":500,"message":"Internal Server Error"}
2026-02-06 10:52:50 | ERROR | ansari.agents.ansari_claude:process_tool_call:521 | Error executing tool search_tafsir_encyc: 500 Server Error: Internal Server Error for url: https://api.usul.ai/v1/vector-search/pet7s2sjr900zvxjsafa3s3b/MT3i8pDNoM?q=%D8%A7%D9%84%D9%88%D8%A7%D9%82%D8%B9%D8%A9+%D8%A3%D8%B5%D8%AD%D8%A7%D8%A8+%D8%A7%D9%84%D9%8A%D9%85%D9%8A%D9%86+%D8%A7%D9%84%D8%AC%D9%86%D8%A9&limit=10&page=1&include_chapters=false
```


Here is the current state:

<img width="386" height="734" alt="image" src="https://github.com/user-attachments/assets/17df0d74-1678-4fc0-9441-10827d6f1c4e" />


